### PR TITLE
chore: migrate ThriveTech-AI refs to martymcenroe (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # HermesWiki
 
-Documentation wiki for [Hermes](https://github.com/ThriveTech-AI/Hermes) — autonomous AI email agent.
+Documentation wiki for [Hermes](https://github.com/martymcenroe/Hermes) — autonomous AI email agent.
 
-**[Go to the Wiki →](https://github.com/ThriveTech-AI/HermesWiki/wiki)**
+**[Go to the Wiki →](https://github.com/martymcenroe/HermesWiki/wiki)**


### PR DESCRIPTION
## Summary
- Update README links from ThriveTech-AI to martymcenroe

Closes #1